### PR TITLE
Role should not fail in check mode

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,6 +27,7 @@
     mode: '0755'
     owner: 'root'
     group: 'root'
+  when: not ansible_check_mode
 
 - name: Create symlink
   file:
@@ -36,3 +37,4 @@
     mode: '0755'
     owner: 'root'
     group: 'root'
+  when: not ansible_check_mode


### PR DESCRIPTION
When running the role in check mode, the permission of the restic rest binary can not be checked and the symlink to the binary can not be created as the restic rest binary might not exist.

Closes: #2