### PR TITLE
Bump restic rest-server version to 0.9.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Role Variables
 --------------
 
 ```yaml
-restic_rest_v: '0.9.4'
+restic_rest_v: '0.9.7'
 restic_rest_repos:
   - path: '/user/home/backup'
     listen: ':8000'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,6 @@
 restic_rest_user: 'root'
 restic_rest_group: 'root'
 restic_rest_binary: 'rest-server'
-restic_rest_v: '0.9.5'
+restic_rest_v: '0.9.7'
 restic_rest_url: 'https://github.com/restic/rest-server/releases/download/v{{ restic_rest_v }}/rest-server-{{ restic_rest_v }}-{{ _platform_suffix }}.gz'
 restic_install_path: '/usr/local/bin'


### PR DESCRIPTION
restic/rest-server is at version 0.9.7 since quite a while now. We should reflect that.