### PR TITLE
Do not cause change when the restic rest-server binary is downloaded

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,6 +15,7 @@
     url: '{{ restic_rest_url }}'
     dest: '/tmp/'
   register: get_url_restic
+  changed_when: false
 
 - name: Decompress the binary
   shell: "gzip -dc {{ get_url_restic.dest }} > {{ restic_install_path }}/{{ restic_rest_binary }}-{{ restic_rest_v }}"


### PR DESCRIPTION
The download of the binary should not cause a change of the
ansible playbook/role. If the destination binary is changed when the
binary is decompressed a change should be signaled.

Closes: donat-b/ansible-restic-rest#5