### PR TITLE
Ensure the backup dirs are mounted

### DIFF
--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -2,6 +2,7 @@
 Description=Restic REST Server ({{ item.path }})
 After=syslog.target network.target
 StopWhenUnneeded=yes
+RequiresMountsFor={{ item.path }}
 
 [Service]
 User={{ item.user | default(restic_rest_user) }}


### PR DESCRIPTION
This ensures that the service is started only when the backup directory is mounted.