### PR TITLE
Bump restic rest-server version to 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ None
 --------------
 
 ```yaml
-restic_rest_v: '0.10.0'
+restic_rest_v: '0.11.0'
 restic_rest_repos:
   - path: '/user/home/backup'
     listen: ':8000'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }
 restic_rest_user: 'root'
 restic_rest_group: 'root'
 restic_rest_binary: 'rest-server'
-restic_rest_v: '0.10.0'
+restic_rest_v: '0.11.0'
 restic_rest_url: 'https://github.com/restic/rest-server/releases/download/v{{ restic_rest_v }}/rest-server_{{ restic_rest_v }}_{{ ansible_system | lower }}_{{ go_arch }}.tar.gz'
 restic_download_dir: "rest-server_{{ restic_rest_v }}_{{ ansible_system | lower }}_{{ go_arch }}"
 restic_install_path: '/usr/local/bin'


### PR DESCRIPTION
restic/rest-server version 0.11.0 has been released a few weeks ago. We should reflect that. Thx!