### PR TITLE
Add Super-Linter next to Ansible Lint check

### DIFF
--- a/.github/workflows/ansible-linting-check.yml
+++ b/.github/workflows/ansible-linting-check.yml
@@ -16,3 +16,5 @@ jobs:
         with:
           targets: "."
           args: ""
+          override-deps: |
+            ansible-lint==5.3.2

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,0 +1,29 @@
+---
+name: Super-Linter Code Base
+
+#
+# Documentation:
+# https://github.com/marketplace/actions/super-linter
+#
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      # Runs the Super-Linter action
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
- Restic rest-server
-=========
+Restic rest-server
+==================
+
+![Lint Code Base](https://github.com/donat-b/ansible-restic-rest/actions/workflows/superlinter.yml/badge.svg)
 
 Deploy rest-server for restic.
 The intended usage pattern is that rest-server instances are behind an edge proxy,
@@ -8,12 +10,12 @@ which would handle authorization and SSL itself, if necessary.
 
 All servers can be started via `systemctl start rest-server.target`
 
- Requirements
+Requirements
 ------------
 
 None
 
- Role Variables
+Role Variables
 --------------
 
 ```yaml
@@ -31,8 +33,7 @@ restic_rest_target: 'rest-server.target default.target'
 restic_rest_target_enable: true
 ```
 
-
- License
+License
 -------
 
 BSD [![License](https://raw.githubusercontent.com/donat-b/ansible-restic-rest/master/.github/license.svg?sanitize=true)](https://github.com/donat-b/ansible-restic-rest/blob/master/LICENSE)


### PR DESCRIPTION
ansible-lint-action seems to have a problem:

  Traceback (most recent call last):
    File "/usr/local/bin/ansible-lint", line 5, in <module>
      from ansiblelint.__main__ import main
    File "/usr/local/lib/python3.8/site-packages/ansiblelint/__main__.py", line 37, in <module>
      from ansiblelint.generate_docs import rules_as_rich, rules_as_rst
    File "/usr/local/lib/python3.8/site-packages/ansiblelint/generate_docs.py", line 6, in <module>
      from rich.console import render_group
  ImportError: cannot import name 'render_group' from 'rich.console' (/usr/local/lib/python3.8/site-packages/rich/console.py)

A workaround exists, see: https://github.com/ansible/ansible-lint-action/issues/59

Super-Linter is well maintained and supports Ansible fine, we should
consider replacing Ansible Lint check.

While at it also fixed some markdown lint errors found in README.md:

  2022-03-05 00:08:30 [INFO]   File:[/github/workspace/README.md]
  2022-03-05 00:08:30 [ERROR]   Found errors in [markdownlint] linter!
  2022-03-05 00:08:30 [ERROR]   Error code: 1. Command output:
  ------
  /github/workspace/README.md:1 MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "![Restic rest-server](https://..."]
  /github/workspace/README.md:3:1 MD023/heading-start-left/header-start-left Headings must start at the beginning of the line [Context: " Restic rest-server"]
  /github/workspace/README.md:13:1 MD023/heading-start-left/header-start-left Headings must start at the beginning of the line [Context: " Requirements"]
  /github/workspace/README.md:18:1 MD023/heading-start-left/header-start-left Headings must start at the beginning of the line [Context: " Role Variables"]
  /github/workspace/README.md:37:1 MD023/heading-start-left/header-start-left Headings must start at the beginning of the line [Context: " License"]