### PR TITLE
Add variable restic_rest_target_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ restic_rest_repos:
     args: '--no-auth --append-only --prometheus'
 restic_rest_target: 'rest-server.target default.target'
 restic_rest_target_enable: true
+restic_rest_target_start: false
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,5 +16,6 @@ restic_download_dir: "rest-server_{{ restic_rest_v }}_{{ ansible_system | lower 
 restic_install_path: '/usr/local/bin'
 restic_rest_target: 'rest-server.target'
 restic_rest_target_enable: false
+restic_rest_target_start: true
 restic_rest_htpasswd_crypt_scheme: 'ldap_sha1'
 restic_rest_no_log: true

--- a/tasks/configure_systemd.yml
+++ b/tasks/configure_systemd.yml
@@ -14,6 +14,7 @@
 - name: Enable service units
   systemd:
     enabled: true
+    state: started
     daemon_reload: true
     name: "rest-server-{{ item.path | hash('sha1') | truncate(6, True, '') }}.service"
   with_items: '{{ restic_rest_repos }}'
@@ -34,4 +35,5 @@
     state: started
     daemon_reload: true
     name: 'rest-server.target'
+  when: restic_rest_target_start
   become: true


### PR DESCRIPTION
rest-server.target gets started when this role is deployed.
When restic_rest_target_enable is true, the services get enabled and
started on boot but the rest-server.target is not.
So when deploying this role after a reboot, rest-server.target gets
started again and causes ansible to report a change.

To prevent triggering a change we implemented the variable
`restic_rest_target_start` which prevents rest-server.target to be
started if set to false. While doing so we also make sure that the
restic service units are started anyway (if `restic_rest_target_enable` is
set to true). That way we do not need to start rest-server.target to
start the service units.

`restic_rest_target_start` defaults to true because we do not want to
change the default behavior, but it seems like we actually do not need
the target anymore.